### PR TITLE
Update signs.css

### DIFF
--- a/css/signs.css
+++ b/css/signs.css
@@ -496,7 +496,6 @@
 }
 
 .shieldImg {
-	width:max-content;
 	height: 3rem;
 }
 


### PR DESCRIPTION
So based on discussion on Issue #5 and discussion on Discord, I found that the problem of stretched shield on Safari or iOS browsers is caused by this line: ``width: max-content;``, and since without this line on Chrome/Edge won't cause new problems on shield display, I think remove this line from stylesheet would be fine while fix stretched shield problem.