### PR TITLE
adjust sizing of signcontainer to improve sign image capture

### DIFF
--- a/css/signs.css
+++ b/css/signs.css
@@ -3,6 +3,8 @@
 	flex-direction: row;
 	height: 30rem;
 	margin-top: 5rem;
+	width: fit-content;
+	justify-self: center;
 }
 
 #postContainer.polePositionOverhead .post {


### PR DESCRIPTION
this should make sign images a lot more reasonable in terms of width