### PR TITLE
Fixed centring for sign preview

### DIFF
--- a/css/signs.css
+++ b/css/signs.css
@@ -2,9 +2,7 @@
 	display: flex;
 	flex-direction: row;
 	height: 30rem;
-	margin-top: 5rem;
-	width: fit-content;
-	justify-self: center;
+	margin-top: 2rem;
 }
 
 #postContainer.polePositionOverhead .post {


### PR DESCRIPTION
Changed the CSS for `#postContainer` in`signs.css` to an older version, which puts the sign container back to the centre

Before: ![image](https://github.com/user-attachments/assets/eb449f42-4ead-44f0-a490-c5cb379bb886)
After: ![image](https://github.com/user-attachments/assets/9c601bee-0021-456d-8c9a-c634c459db66)

